### PR TITLE
test: import JsonRpcProvider from ethers v6 (fix v5/v6 type mismatch)

### DIFF
--- a/test/multichain-setup.test.ts
+++ b/test/multichain-setup.test.ts
@@ -8,7 +8,7 @@ import ChainManager, {
 } from "../src/chainManager";
 // Don't import the full plugin here to avoid hardhat context issues
 // import "../src/index"; // Ensure the plugin is loaded
-import { JsonRpcProvider } from "@ethersproject/providers";
+import { JsonRpcProvider } from "ethers";
 import { jest } from "@jest/globals";
 
 let hre: HardhatRuntimeEnvironment;


### PR DESCRIPTION
## Summary
`test/multichain-setup.test.ts` imported `JsonRpcProvider` from `@ethersproject/providers` (ethers v5 typings) and passed it where the code expects ethers v6's `JsonRpcProvider`. The two are structurally incompatible (`#private` fields), so the suite failed to compile under ts-jest. Import from `ethers` (v6) instead.

## Verification
- `yarn test` (jest): the previously-failing `multichain-setup.test.ts` now passes (51/51); no v5/v6 type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
